### PR TITLE
Demonstrate an alternative way of fixing version numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# SBT
+target/
+
+# IDE
+.idea


### PR DESCRIPTION
Hi Jean,

Your [blog post](http://blog.byjean.eu/2015/07/10/painless-release-with-sbt.html) is great; it's been very useful to us recently.

I'd like to highlight a potential improvement to this, regarding where you work around the incorrectly numbered snapshot build issue.

Your code (adding the `bump` operation to the `releaseVersion` setting) fixes the version numbering around doing releases, which is great.  But if I run `sbt version` I'll still get `a.b.c-SNAPSHOT` if `a.b.c` is the version that's most recently been released.  According to Maven convention, the snapshot should have the numering for the *next* candidate release, e.g. `a.b+1.c-SNAPSHOT` if you're using a minor bump strategy.

Instead of overridding `releaseVersion`, the alternative approach we've taken is to tweak the `gitTagToVersionNumber` logic to do the bumping in there for snapshot versions.

This PR demonstrates the difference (no need to merge if you don't want to, it's just for information!); also you can see how we're using this in a real project we just open sourced (https://github.com/sky-uk/kafka-configurator/blob/master/project/Git.scala#L8-L17).  That project also uses SBT 0.13.15 (at the time of writing) so it shows your ideas using the updated SBT conventions.

Hope this is interesting to you and useful to others.

Thanks


Olly